### PR TITLE
Hotfix/cursor moves unintentionally

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
-            "preLaunchTask": "npm: build:webview"
+            "preLaunchTask": "npm: build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,10 +15,10 @@
         },
         {
             "type": "npm",
-            "script": "build:webview",
+            "script": "build",
             "group": "build",
             "problemMatcher": [],
-            "label": "npm: build:webview",
+            "label": "npm: build",
             "detail": "vite build"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Useful for writing Japanese novels and literature!
 3. Run `npx vsce package` to create VSIX file
 4. Install VSIX file
     ```
-    code --install-extension vertedit-0.1.1.vsix
+    code --install-extension vertedit-0.1.2.vsix
     ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vertedit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vertedit",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   "scripts": {
     "vscode:prepublish": "npm run compile && npm run build:webview",
     "compile": "tsc -p ./",
+    "build": "npm run compile && vite build",
     "build:webview": "vite build",
     "watch": "concurrently \"tsc -watch -p ./\" \"vite build --watch\"",
     "watch:webview": "vite build --watch",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vertedit",
   "displayName": "VertEdit",
   "description": "A VS Code extension for WYSIWYG vertical text editing",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "k.rainfield",
   "license": "MIT",
   "repository": {

--- a/webview-src/utils/cursorPositionUtils.ts
+++ b/webview-src/utils/cursorPositionUtils.ts
@@ -65,11 +65,15 @@ export const mergeCurrentLineWithPrevious = (
   const previousParagraph = currentParagraph?.previousElementSibling as HTMLElement;
   
   if (previousParagraph && currentParagraph) {
-    const isEmpty = previousParagraph.innerHTML.trim() === '<br>' || 
+    const isPreviousParagraphEmpty = previousParagraph.innerHTML.trim() === '<br>' || 
                    previousParagraph.innerHTML.trim() === '<br/>' || 
                    previousParagraph.innerHTML.trim() === '<br />';
-    
-    if (isEmpty) {
+
+    const isCurrentParagraphEmpty = currentParagraph.innerHTML.trim() === '<br>' || 
+                   currentParagraph.innerHTML.trim() === '<br/>' || 
+                   currentParagraph.innerHTML.trim() === '<br />';
+
+    if (isPreviousParagraphEmpty) {
       previousParagraph.innerHTML = '';
       while (currentParagraph.firstChild) {
         previousParagraph.appendChild(currentParagraph.firstChild);
@@ -92,8 +96,12 @@ export const mergeCurrentLineWithPrevious = (
       selection?.addRange(newRange);
     } else {
       const originalTextLength = previousParagraph.textContent?.length || 0;
-      while (currentParagraph.firstChild) {
-        previousParagraph.appendChild(currentParagraph.firstChild);
+      if (isCurrentParagraphEmpty) {
+        // no-op
+      } else {
+        while (currentParagraph.firstChild) {
+          previousParagraph.appendChild(currentParagraph.firstChild);
+        }
       }
       const cursorPos = findTextCursorPosition(previousParagraph, originalTextLength);
       const newRange = document.createRange();


### PR DESCRIPTION
# Problem
When users press backspace to merge a previous non-blank line with the current blank line, the caret position incorrectly moves to the top of the editor due to caret handling logic.

# Changes
Added a new case to the caret handling logic to address this issue

# Testing
- Unit tests pass
- Functionality verified locally